### PR TITLE
Disable AP mode

### DIFF
--- a/homeduino-esp8266-node.ino
+++ b/homeduino-esp8266-node.ino
@@ -13,7 +13,7 @@ void setup()
   Serial.println();
   Serial.print("Connecting to ");
   Serial.println(SSID);
-  
+  WiFi.mode(WIFI_STA);
   WiFi.begin(SSID, PASSWORD);
   
   while (WiFi.status() != WL_CONNECTED) {  


### PR DESCRIPTION
Without this the AP mode is active while connected to your WIFI.
AP mode is unsecured.
